### PR TITLE
fix key mapping for TagbarToggle to be consistent with documentation

### DIFF
--- a/rc/mappings.vim
+++ b/rc/mappings.vim
@@ -167,7 +167,8 @@ nnoremap <silent> X :BufSurfForward<cr>
 nnoremap <silent> <leader>v :Page<cr>
 
 " tagbar
-nnoremap <silent> <c-g> :TagbarToggle<cr>
+nnoremap <silent> <leader>t :TagbarToggle<cr>
+nnoremap <silent> <leader>2 :TagbarToggle<cr>
 
 " tabularize
 nnoremap <leader>a&     :Tabularize /&<cr>


### PR DESCRIPTION
Hi @joshuarubin, alternatively, we can update `README.md` to list the `<c-g>` mapping.

Separately, VERY nice work!! 👍 